### PR TITLE
Create reliable RPC that is executed on the server for player movemen…

### DIFF
--- a/DungeonRaider/Source/DungeonRaider/DR_Character.h
+++ b/DungeonRaider/Source/DungeonRaider/DR_Character.h
@@ -31,17 +31,7 @@ class DUNGEONRAIDER_API ADR_Character : public ACharacter
 public:
 	// Sets default values for this character's properties
 	ADR_Character();
-
-protected:
-	// Called when the game starts or when spawned
-	virtual void BeginPlay() override;
-	void Move(const struct FInputActionValue& Value);
-	void Look(const FInputActionValue& Value);
-	void SprintStart(const FInputActionValue& Value);
-	void SprintEnd(const FInputActionValue& Value);
-	void Interact(const FInputActionValue& Value);
-
-public:	
+	
 	// Called every frame
 	virtual void Tick(float DeltaTime) override;
 
@@ -53,4 +43,19 @@ public:
 
 	void UpdateCharacterStats(int32 CharacterLevel);
 	FORCEINLINE FDR_CharacterStats* GetCharacterStats() const { return CharacterStats; }
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+	void Move(const struct FInputActionValue& Value);
+	void Look(const FInputActionValue& Value);
+	void SprintStart(const FInputActionValue& Value);
+	void SprintEnd(const FInputActionValue& Value);
+	void Interact(const FInputActionValue& Value);
+
+	// Remote Procedure Calls
+	UFUNCTION(Server, Reliable)
+	void Server_SprintStart();
+	UFUNCTION(Server, Reliable)
+	void Server_SprintEnd();
 };


### PR DESCRIPTION
…t; Server now controls player movement speed based on the player's level; Fix issue with player reverting to walking when levelling up by adding a check to see whether they are sprinting while levelling up and then calling the sprint start RPC on the server